### PR TITLE
add .gitattributes to tag the repository language as R 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-vendored


### PR DESCRIPTION
GitHub's algorithm is classifying this repository's language as HTML which might hide it
from users' searches.

For instance, a user who is searching for "covariance matrix estimation", (as in https://github.com/search?q=covariance+matrix+estimation&type=Repositories), would have to go on the HTML language section in order to find ``covFactorModel``. 

This PR fixes this minor issue by telling GitHub to ignore HTML files in their language classification algorithm.